### PR TITLE
Alphafold: fix exit code in non-pulsar mode

### DIFF
--- a/tools/alphafold/alphafold.xml
+++ b/tools/alphafold/alphafold.xml
@@ -70,7 +70,7 @@ cp output/alphafold/ranked_*.pdb '${html.files_path}' &&
 ## This is a (hacky) fix for a bug that has appeared in multiple Pulsar servers.
 ## The working directory ends up two levels deep and the visualization html page
 ## fails to load the PDB files as static assets.
-[ -d working ] && cp -r working/* .
+(([ -d working ] && cp -r working/* .) || true)
 
     ]]></command>
     <inputs>


### PR DESCRIPTION
Hi!
I'm testing alphafold on usegalaxy.fr, it runs well (good work :clap:), except that the outputs appear in error, even though their content is ok.
From what I've understand, it comes from the "(hacky) fix" for pulsar: we don't use pulsar for this tool on .fr, so the `working` subdir is not there leading to a non-zero exit code.

I added a bit of bash magic to fix it, I think the only case where it's still wrong is if `working` exists but `cp` fails -> the exit code will be 0. I can live with that though, and I don't see how we could handle this case properly.