### PR TITLE
Update cactus v2.2.4 -> 2.4.0

### DIFF
--- a/tools/cactus/cactus_cactus.xml
+++ b/tools/cactus/cactus_cactus.xml
@@ -150,7 +150,7 @@
             </repeat>
             <output name="out_hal">
                 <assert_contents>
-                    <has_size value="4783905" delta="200000" />
+                    <has_size value="4472551" delta="200000" />
                 </assert_contents>
             </output>
         </test>

--- a/tools/cactus/cactus_cactus.xml
+++ b/tools/cactus/cactus_cactus.xml
@@ -1,5 +1,5 @@
 <tool id="cactus_cactus" name="Cactus" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@" license="MIT">
-    <description>whole-genome multiple sequence alignment.</description>
+    <description>whole-genome multiple sequence alignment</description>
     <macros>
         <import>macros.xml</import>
     </macros>
@@ -61,15 +61,13 @@
             &&
             cactus-graphmap-join
             --binariesMode local
-            --gfaffix 
             --giraffe
             --maxCores  \${GALAXY_SLOTS:-4}
             --maxMemory \${GALAXY_MEMORY_MB:-8192}M
-            --outDir ./
             --outName alignment
             --reference $aln_mode.ref_level
             --vg alignment.vg
-            --wlineSep "." 
+            --outDir ./
             ./jobStore
         #else if $aln_mode.aln_mode_select == 'interspecies':
             ## Run cactus normally
@@ -92,14 +90,28 @@
                 <param name="in_tree" type="data" format="nhx" label="Guide tree" help="Phylogenetic tree in Newick format. Required by Cactus to achieve linear scaling with number of input genomes" />
             </when>
             <when value="intraspecies">
-                <param name="ref_level" type="text" value="" label="Reference genome" help="Pangenomes from Minigraph-Cactus depend on a predetermined reference genome. Specify one of the Input Genomes as the reference genome. This must match the label used in 'Genome Label'." />
+                <param name="ref_level" type="text" value="" label="Reference genome" help="Pangenomes from Minigraph-Cactus depend on a predetermined reference genome. Specify one of the Input Genomes as the reference genome. This must match the label used in 'Genome Label'.">
+                    <sanitizer invalid_char="">
+                        <valid initial="string.letters,string.digits">
+                            <add value="_" />
+                        </valid>
+                    </sanitizer>
+                    <validator type="regex">[0-9a-zA-Z_]+</validator>
+                </param>
             </when>
         </conditional>
         <repeat name="in_seqs" title="Input genome">
-            <param name="label" type="text" value="" label="Genome Label" help="NO SPACES. Must match a label in the guide tree.">
+            <param name="label" type="text" value="" label="Genome label" help="NO SPACES. Must match a label in the guide tree.">
+                <sanitizer invalid_char="">
+                    <valid initial="string.letters,string.digits">
+                        <add value="_" />
+                    </valid>
+                </sanitizer>
+                <validator type="regex">[0-9a-zA-Z_]+</validator>
             </param>
             <param name="fasta" type="data" format="fasta,fasta.gz" label="Genome Sequence" help="Input genome"/>
         </repeat>
+
         <!-- add an option for root -->
         <!-- root mr  -->
     </inputs>
@@ -235,11 +247,18 @@
         </test>
     </tests>
         <help><![CDATA[
+
+.. class:: infomark
+
 **What it does**
 
 `Cactus <https://github.com/ComparativeGenomicsToolkit/cactus>`__ is a
 reference-free whole-genome multiple alignment program. It can be used
 to progressively align a large number of genomes.
+
+-----
+
+.. class:: infomark
 
 **Usage**
 
@@ -253,9 +272,9 @@ possible pairs of genomes.
 A Newick-formatted tree for human, chimp and gorilla genomes looks like
 this:
 
-::
+    ::
 
-   (((human:0.006,chimp:0.006667):0.0022,gorilla:0.008825):0.0096,orang:0.01831);
+        (((human:0.006,chimp:0.006667):0.0022,gorilla:0.008825):0.0096,orang:0.01831);
 
 The numbers are the branch lengths.
 
@@ -270,7 +289,11 @@ the input genomes and then use the graph to order the alignments. To use
 pangenome mode, select ‘Within-species’ in the ‘Alignment mode’
 dropdown.
 
-Unlike Between-species mode, Within-species mode depends on a predetermined reference genome
+Unlike Between-species mode, Within-species mode depends on a predetermined reference genome.
+
+-----
+
+.. class:: infomark
 
 **Input**
 
@@ -280,6 +303,10 @@ before running Cactus. RepeatMasker is available on Galaxy.
 If you’re using Between-species mode, you need to provide labels for the
 fasta files that match the leaves on the guide tree. In the example
 above, you would use the label ‘human’ for the human fasta file.
+
+-----
+
+.. class:: infomark
 
 **Output**
 

--- a/tools/cactus/cactus_export.xml
+++ b/tools/cactus/cactus_export.xml
@@ -1,5 +1,5 @@
 <tool id="cactus_export" name="Cactus: export" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@" license="MIT">
-    <description>whole-genome multiple sequence alignment to other formats.</description>
+    <description>whole-genome multiple sequence alignment to other formats</description>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/cactus/macros.xml
+++ b/tools/cactus/macros.xml
@@ -1,13 +1,12 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.4</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">2.4.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
-    <token name="@DIGEST@">b22eb2ef1d8c6f152d12d0e4300ac68affea5aafb2f7022f9078e8e72e41654d</token>
     <xml name="requirements">
         <requirements>
             <!-- Cactus is not in bioconda -->
             <!-- Devoper provides a Docker container -->
-            <container type="docker">quay.io/comparative-genomics-toolkit/cactus@sha256:@DIGEST@</container>
+            <container type="docker">quay.io/comparative-genomics-toolkit/cactus:v@TOOL_VERSION@</container>
         </requirements>
     </xml>
     <xml name="citations">


### PR DESCRIPTION
Some parameters have been removed from the wrapper because have been removed in version 2.3.0.

More information about the updates: https://github.com/ComparativeGenomicsToolkit/cactus/releases