### PR TITLE
Add hifiasm_meta to the toolshed

### DIFF
--- a/tools/hifiasm_meta/.shed.yml
+++ b/tools/hifiasm_meta/.shed.yml
@@ -1,10 +1,17 @@
-name: hifiasm_meta
-owner: iuc
+---
+categories:
+  - Metagenomics
 description: A hifiasm fork for metagenome assembly using Hifi reads.
+exclude:
+  - extras
+  - tool_test_output.html
+  - tool_test_output.json
 homepage_url: https://github.com/xfengnefx/hifiasm-meta
 long_description: |
-     de novo metagenome assembler, based on hifiasm, a haplotype-resolved de novo assembler for PacBio Hifi reads
-remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/hifiasm_meta
+  de novo metagenome assembler, based on hifiasm, a haplotype-resolved de
+  novo assembler for PacBio Hifi reads
+name: hifiasm_meta
+owner: galaxy-australia
+remote_repository_url: >
+  https://github.com/galaxyproject/tools-iuc/tree/master/tools/hifiasm_meta
 type: unrestricted
-categories:
-- Metagenomics

--- a/tools/hifiasm_meta/.shed.yml
+++ b/tools/hifiasm_meta/.shed.yml
@@ -12,6 +12,5 @@ long_description: |
   novo assembler for PacBio Hifi reads
 name: hifiasm_meta
 owner: galaxy-australia
-remote_repository_url: >
-  https://github.com/galaxyproject/tools-iuc/tree/master/tools/hifiasm_meta
+remote_repository_url: https://github.com/usegalaxy-au/tools-au
 type: unrestricted


### PR DESCRIPTION
I can't get `hifiasm_meta` to pass the tools-iuc tests so I'm putting it on the toolshed.

See https://github.com/galaxyproject/tools-iuc/pull/5033