### PR TITLE
Update plot_ragtag_paf.R - bug fix

### DIFF
--- a/tools/plot_ragtag_paf/plot_ragtag_paf.R
+++ b/tools/plot_ragtag_paf/plot_ragtag_paf.R
@@ -194,7 +194,7 @@ total_height <- (q_y - t_y) * 1.618
 y_axis_space <- (total_height - (q_y - t_y)) / 2
 middle_x <- tpaf[1, shift_tstart] + tpaf[.N, pad_tend] / 2
 
-all_contig_names <- c(tpaf[, unique(tname)])
+all_contig_names <- as.character(c(tpaf[, unique(tname)]))
 all_colours <- viridis(
     length(all_contig_names) + palette_space + 1
 )

--- a/tools/plot_ragtag_paf/plot_ragtag_paf.R
+++ b/tools/plot_ragtag_paf/plot_ragtag_paf.R
@@ -194,7 +194,7 @@ total_height <- (q_y - t_y) * 1.618
 y_axis_space <- (total_height - (q_y - t_y)) / 2
 middle_x <- tpaf[1, shift_tstart] + tpaf[.N, pad_tend] / 2
 
-all_contig_names <- as.character(c(tpaf[, unique(tname)]))
+all_contig_names <- tpaf[, levels(tname)]
 all_colours <- viridis(
     length(all_contig_names) + palette_space + 1
 )

--- a/tools/plot_ragtag_paf/plot_ragtag_paf.xml
+++ b/tools/plot_ragtag_paf/plot_ragtag_paf.xml
@@ -1,4 +1,4 @@
-<tool id="plot_ragtag_paf" name="Plot RagTag output" version="0.0.4" profile="24.1" license="MIT">
+<tool id="plot_ragtag_paf" name="Plot RagTag output" version="0.0.5" profile="24.1" license="MIT">
     <description>to compare query contigs to the reference</description>
     <requirements>
         <container type="docker">ghcr.io/tomharrop/r-containers:r2u_24.04_cv1</container>


### PR DESCRIPTION
bug fix: changed class of all_contig_names from factor to character so all_colours gets correct contig names rather than level numbers. This gets the reference contig plot colours to follow the viridis colour palette rather than plotting them all in grey and generating the warnings: 
Warning messages:
1: No shared levels found between `names(values)` of the manual scale and the data's fill values. 
2: No shared levels found between `names(values)` of the manual scale and the data's colour values.